### PR TITLE
Fixed typo in build_all.sh

### DIFF
--- a/tree_example/build_all.sh
+++ b/tree_example/build_all.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 mkdir -p build && cd build
 cmake ..
 cmake --build .

--- a/vector_example/build_all.sh
+++ b/vector_example/build_all.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 mkdir -p build && cd build
 cmake ..
 cmake --build .


### PR DESCRIPTION
Без восклицательного знака 
#/bin/bash
просто комментарий.